### PR TITLE
エラー修正: Uncaught ReferenceError

### DIFF
--- a/frontend/src/control-gate.ts
+++ b/frontend/src/control-gate.ts
@@ -7,6 +7,10 @@ import { SerializeableMixin } from "./serializeable-mixin";
 export class ControlGate extends OutlinedGateMixin(
   SerializeableMixin(JsonableMixin(LabelableMixin(OperationComponent)))
 ) {
+  get operationType(): string {
+    return "ControlGate";
+  }
+
   get label(): string {
     return "@";
   }

--- a/frontend/src/h-gate.ts
+++ b/frontend/src/h-gate.ts
@@ -7,6 +7,10 @@ import { SquareGateMixin } from "./square-gate-mixin";
 export class HGate extends SquareGateMixin(
   SerializeableMixin(JsonableMixin(LabelableMixin(OperationComponent)))
 ) {
+  get operationType(): string {
+    return "HGate";
+  }
+
   get label(): string {
     return "H";
   }

--- a/frontend/src/measurement-gate.ts
+++ b/frontend/src/measurement-gate.ts
@@ -7,15 +7,20 @@ import { Assets, Texture } from "pixi.js";
 import { LabelableMixin } from "./labelable-mixin";
 import { SerializeableMixin } from "./serializeable-mixin";
 
+import icon0Path from "../assets/measurement-gate0.png";
+import icon1Path from "../assets/measurement-gate1.png";
+
 export class MeasurementGate extends OutlinedGateMixin(
   SerializeableMixin(JsonableMixin(LabelableMixin(OperationComponent)))
 ) {
-  static readonly _icon0Path = "/assets/measurement-gate0.png";
-  static readonly _icon1Path = "/assets/measurement-gate1.png";
   static _icon0: Texture;
   static _icon1: Texture;
 
   _value: "" | 0 | 1 = "";
+
+  get operationType(): string {
+    return "MeasurementGate";
+  }
 
   get label(): string {
     return "M";
@@ -42,8 +47,8 @@ export class MeasurementGate extends OutlinedGateMixin(
   async createSprites() {
     const sprites = await super.createSprites(this.operationType);
 
-    MeasurementGate._icon0 = await Assets.load(MeasurementGate._icon0Path);
-    MeasurementGate._icon1 = await Assets.load(MeasurementGate._icon1Path);
+    MeasurementGate._icon0 = await Assets.load(icon0Path);
+    MeasurementGate._icon1 = await Assets.load(icon1Path);
 
     return sprites;
   }

--- a/frontend/src/operation-component.ts
+++ b/frontend/src/operation-component.ts
@@ -158,7 +158,7 @@ export class OperationComponent extends IconableMixin(Container) {
   private actor!: ActorRefFrom<typeof this.stateMachine>;
 
   get operationType(): string {
-    return this.constructor.name;
+    throw new Error("operationType must be implemented in derived class");
   }
 
   get gateSource(): OperationSource | null {

--- a/frontend/src/qubit-circle-manager.ts
+++ b/frontend/src/qubit-circle-manager.ts
@@ -1,4 +1,4 @@
-import * as PIXI from "pixi.js";
+import { Container, Point } from "pixi.js";
 import { QubitCircle } from "./qubit-circle";
 import { Size } from "./size";
 import { StateVectorLayout } from "./state-vector-layout";
@@ -6,10 +6,10 @@ import { StateVectorLayout } from "./state-vector-layout";
 export class QubitCircleManager {
   private circles: Map<string, QubitCircle> = new Map();
   private layout: StateVectorLayout;
-  private container: PIXI.Container;
+  private container: Container;
   private _visibleQubitCircleIndices: Set<number> = new Set();
 
-  constructor(layout: StateVectorLayout, container: PIXI.Container) {
+  constructor(layout: StateVectorLayout, container: Container) {
     this.layout = layout;
     this.container = container;
   }
@@ -68,7 +68,7 @@ export class QubitCircleManager {
     });
   }
 
-  private createQubitCircle(position: PIXI.Point): void {
+  private createQubitCircle(position: Point): void {
     const circle = new QubitCircle(this.layout.qubitCircleSize);
     const key = this.circleKeyAt(position);
 
@@ -79,7 +79,7 @@ export class QubitCircleManager {
 
   private updateQubitCirclePositionAndSize(
     circle: QubitCircle,
-    position: PIXI.Point
+    position: Point
   ): void {
     circle.position.copyFrom(position);
     circle.size = this.layout.qubitCircleSize;
@@ -96,7 +96,7 @@ export class QubitCircleManager {
     });
   }
 
-  private circleKeyAt(position: PIXI.Point): string {
+  private circleKeyAt(position: Point): string {
     return `${position.x},${position.y}`;
   }
 }

--- a/frontend/src/rnot-gate.ts
+++ b/frontend/src/rnot-gate.ts
@@ -7,6 +7,10 @@ import { SquareGateMixin } from "./square-gate-mixin";
 export class RnotGate extends SquareGateMixin(
   SerializeableMixin(JsonableMixin(LabelableMixin(OperationComponent)))
 ) {
+  get operationType(): string {
+    return "RnotGate";
+  }
+
   get label(): string {
     return "√X";
   }

--- a/frontend/src/s-dagger-gate.ts
+++ b/frontend/src/s-dagger-gate.ts
@@ -7,6 +7,10 @@ import { SquareGateMixin } from "./square-gate-mixin";
 export class SDaggerGate extends SquareGateMixin(
   SerializeableMixin(JsonableMixin(LabelableMixin(OperationComponent)))
 ) {
+  get operationType(): string {
+    return "SDaggerGate";
+  }
+
   get label(): string {
     return "S†";
   }

--- a/frontend/src/s-gate.ts
+++ b/frontend/src/s-gate.ts
@@ -7,6 +7,10 @@ import { SquareGateMixin } from "./square-gate-mixin";
 export class SGate extends SquareGateMixin(
   SerializeableMixin(JsonableMixin(LabelableMixin(OperationComponent)))
 ) {
+  get operationType(): string {
+    return "SGate";
+  }
+
   get label(): string {
     return "S";
   }

--- a/frontend/src/state-vector-component.ts
+++ b/frontend/src/state-vector-component.ts
@@ -1,5 +1,4 @@
-import * as PIXI from "pixi.js";
-import { Container } from "pixi.js";
+import { Rectangle, Container } from "pixi.js";
 import { QubitCircle } from "./qubit-circle";
 import { QubitCount } from "./types";
 import { STATE_VECTOR_EVENTS } from "./state-vector-events";
@@ -15,7 +14,7 @@ class InvalidQubitCountError extends Error {
 
 export interface StateVectorConfig {
   initialQubitCount: QubitCount;
-  viewport: PIXI.Rectangle;
+  viewport: Rectangle;
 }
 
 /**
@@ -58,7 +57,7 @@ export class StateVectorComponent extends Container {
     this.setViewport(config.viewport);
   }
 
-  setViewport(viewport: PIXI.Rectangle) {
+  setViewport(viewport: Rectangle) {
     const visibleQubitCirclesChanged = this.renderer.setViewport(viewport);
 
     if (visibleQubitCirclesChanged) {

--- a/frontend/src/state-vector-frame.ts
+++ b/frontend/src/state-vector-frame.ts
@@ -1,4 +1,4 @@
-import * as PIXI from "pixi.js";
+import { Container, Graphics, Rectangle } from "pixi.js";
 import { Colors } from "./colors";
 import { StateVectorComponent } from "./state-vector-component";
 import { throttle } from "lodash";
@@ -7,7 +7,7 @@ import { STATE_VECTOR_EVENTS } from "./state-vector-events";
 /**
  * スクロール機能つきフレーム。状態ベクトルを表示する。
  */
-export class StateVectorFrame extends PIXI.Container {
+export class StateVectorFrame extends Container {
   private static instance: StateVectorFrame | null = null;
   private static readonly PADDING_MULTIPLIER: number = 2;
 
@@ -15,9 +15,9 @@ export class StateVectorFrame extends PIXI.Container {
 
   private frameWidth: number;
   private frameHeight: number;
-  private readonly background: PIXI.Graphics;
-  private maskGraphics: PIXI.Graphics;
-  private scrollContainer: PIXI.Container;
+  private readonly background: Graphics;
+  private maskGraphics: Graphics;
+  private scrollContainer: Container;
 
   static initialize(width: number, height: number): StateVectorFrame {
     if (!this.instance) {
@@ -40,13 +40,13 @@ export class StateVectorFrame extends PIXI.Container {
 
     this.frameWidth = width;
     this.frameHeight = height;
-    this.background = new PIXI.Graphics();
+    this.background = new Graphics();
     this.stateVector = new StateVectorComponent({
       initialQubitCount: 1,
-      viewport: new PIXI.Rectangle(0, 0, width, height),
+      viewport: new Rectangle(0, 0, width, height),
     });
-    this.maskGraphics = new PIXI.Graphics();
-    this.scrollContainer = new PIXI.Container();
+    this.maskGraphics = new Graphics();
+    this.scrollContainer = new Container();
 
     this.initializeBackground();
     this.updateMask();
@@ -59,7 +59,7 @@ export class StateVectorFrame extends PIXI.Container {
     this.scrollContainer.mask = this.maskGraphics;
 
     // StateVectorComponentにスクロール位置を伝える
-    const scrollRect = new PIXI.Rectangle(
+    const scrollRect = new Rectangle(
       -this.scrollContainer.x,
       -this.scrollContainer.y,
       this.frameWidth,
@@ -173,7 +173,7 @@ export class StateVectorFrame extends PIXI.Container {
     );
 
     // StateVectorComponentにスクロール位置を伝える
-    const scrollRect = new PIXI.Rectangle(
+    const scrollRect = new Rectangle(
       -this.scrollContainer.x,
       -this.scrollContainer.y,
       this.frameWidth,

--- a/frontend/src/state-vector-layout.ts
+++ b/frontend/src/state-vector-layout.ts
@@ -1,4 +1,4 @@
-import * as PIXI from "pixi.js";
+import { Point } from "pixi.js";
 import { QubitCount } from "./types";
 import { Size } from "./size";
 import { Spacing } from "./spacing";
@@ -109,7 +109,7 @@ export class StateVectorLayout {
     endIndexX: number,
     endIndexY: number
   ) {
-    const circles: { position: PIXI.Point; index: number }[] = [];
+    const circles: { position: Point; index: number }[] = [];
     const maxVisibleCircles =
       Math.ceil(this.width / this._cellSize) *
       Math.ceil(this.height / this._cellSize);
@@ -124,7 +124,7 @@ export class StateVectorLayout {
         const posX = this.padding + x * this._cellSize;
         const posY = this.padding + y * this._cellSize;
         const index = y * this.cols + x;
-        circles.push({ position: new PIXI.Point(posX, posY), index });
+        circles.push({ position: new Point(posX, posY), index });
         count++;
       }
     }
@@ -132,13 +132,13 @@ export class StateVectorLayout {
     return circles;
   }
 
-  qubitCirclePositionAt(index: number): PIXI.Point {
+  qubitCirclePositionAt(index: number): Point {
     const x = index % this.cols;
     const y = Math.floor(index / this.cols);
     const posX = this.padding + x * this._cellSize;
     const posY = this.padding + y * this._cellSize;
 
-    return new PIXI.Point(posX, posY);
+    return new Point(posX, posY);
   }
 
   private update(): void {

--- a/frontend/src/state-vector-renderer.ts
+++ b/frontend/src/state-vector-renderer.ts
@@ -1,4 +1,4 @@
-import * as PIXI from "pixi.js";
+import { Container, Graphics, Rectangle } from "pixi.js";
 import { Colors } from "./colors";
 import { QubitCircle } from "./qubit-circle";
 import { QubitCircleManager } from "./qubit-circle-manager";
@@ -10,21 +10,21 @@ import { logger } from "./util";
 export class StateVectorRenderer {
   private layout: StateVectorLayout;
   private qubitCircleManager: QubitCircleManager;
-  private backgroundGraphics: PIXI.Graphics;
-  private container: PIXI.Container;
-  private currentViewport: PIXI.Rectangle;
+  private backgroundGraphics: Graphics;
+  private container: Container;
+  private currentViewport: Rectangle;
   private visibleQubitCirclesStartIndexX: number = 0;
   private visibleQubitCirclesStartIndexY: number = 0;
 
   constructor(
-    container: PIXI.Container,
+    container: Container,
     qubitCount: QubitCount,
-    viewport: PIXI.Rectangle
+    viewport: Rectangle
   ) {
     this.container = container;
     this.layout = new StateVectorLayout(qubitCount);
     this.currentViewport = viewport;
-    this.backgroundGraphics = new PIXI.Graphics();
+    this.backgroundGraphics = new Graphics();
     this.container.addChildAt(this.backgroundGraphics, 0);
     this.qubitCircleManager = new QubitCircleManager(
       this.layout,
@@ -70,7 +70,7 @@ export class StateVectorRenderer {
     this.qubitCircleManager.resizeAllQubitCircles(this.layout.qubitCircleSize);
   }
 
-  setViewport(viewport: PIXI.Rectangle): boolean {
+  setViewport(viewport: Rectangle): boolean {
     const newVisibleQubitCirclesStartIndexX =
       this.layout.visibleQubitCirclesStartIndex(viewport.x);
     const newVisibleQubitCirclesStartIndexY =

--- a/frontend/src/swap-gate.ts
+++ b/frontend/src/swap-gate.ts
@@ -7,6 +7,10 @@ import { SerializeableMixin } from "./serializeable-mixin";
 export class SwapGate extends OutlinedGateMixin(
   SerializeableMixin(JsonableMixin(LabelableMixin(OperationComponent)))
 ) {
+  get operationType(): string {
+    return "SwapGate";
+  }
+
   get label(): string {
     return "×";
   }

--- a/frontend/src/t-dagger-gate.ts
+++ b/frontend/src/t-dagger-gate.ts
@@ -7,6 +7,10 @@ import { SquareGateMixin } from "./square-gate-mixin";
 export class TDaggerGate extends SquareGateMixin(
   SerializeableMixin(JsonableMixin(LabelableMixin(OperationComponent)))
 ) {
+  get operationType(): string {
+    return "TDaggerGate";
+  }
+
   get label(): string {
     return "T†";
   }

--- a/frontend/src/t-gate.ts
+++ b/frontend/src/t-gate.ts
@@ -7,6 +7,10 @@ import { SquareGateMixin } from "./square-gate-mixin";
 export class TGate extends SquareGateMixin(
   SerializeableMixin(JsonableMixin(LabelableMixin(OperationComponent)))
 ) {
+  get operationType(): string {
+    return "TGate";
+  }
+
   get label(): string {
     return "T";
   }

--- a/frontend/src/write0-gate.ts
+++ b/frontend/src/write0-gate.ts
@@ -7,6 +7,10 @@ import { WriteGateMixin } from "./write-gate-mixin";
 export class Write0Gate extends WriteGateMixin(
   SerializeableMixin(JsonableMixin(LabelableMixin(OperationComponent)))
 ) {
+  get operationType(): string {
+    return "Write0Gate";
+  }
+
   get label(): string {
     return "0";
   }

--- a/frontend/src/write1-gate.ts
+++ b/frontend/src/write1-gate.ts
@@ -7,6 +7,10 @@ import { WriteGateMixin } from "./write-gate-mixin";
 export class Write1Gate extends WriteGateMixin(
   SerializeableMixin(JsonableMixin(LabelableMixin(OperationComponent)))
 ) {
+  get operationType(): string {
+    return "Write1Gate";
+  }
+
   get label(): string {
     return "1";
   }

--- a/frontend/src/x-gate.ts
+++ b/frontend/src/x-gate.ts
@@ -13,6 +13,10 @@ export class XGate extends CircularGateMixin(
 
   private _controls: number[] = [];
 
+  get operationType(): string {
+    return "XGate";
+  }
+
   get label(): string {
     return "X";
   }

--- a/frontend/src/y-gate.ts
+++ b/frontend/src/y-gate.ts
@@ -7,6 +7,10 @@ import { SquareGateMixin } from "./square-gate-mixin";
 export class YGate extends SquareGateMixin(
   SerializeableMixin(JsonableMixin(LabelableMixin(OperationComponent)))
 ) {
+  get operationType(): string {
+    return "YGate";
+  }
+
   get label(): string {
     return "Y";
   }

--- a/frontend/src/z-gate.ts
+++ b/frontend/src/z-gate.ts
@@ -7,6 +7,10 @@ import { SquareGateMixin } from "./square-gate-mixin";
 export class ZGate extends SquareGateMixin(
   SerializeableMixin(JsonableMixin(LabelableMixin(OperationComponent)))
 ) {
+  get operationType(): string {
+    return "ZGate";
+  }
+
   get label(): string {
     return "Z";
   }

--- a/frontend/tests/vitest/state-vector-component.test.ts
+++ b/frontend/tests/vitest/state-vector-component.test.ts
@@ -1,4 +1,4 @@
-import * as PIXI from "pixi.js";
+import { Rectangle } from "pixi.js";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { QubitCircle } from "../../src/qubit-circle";
 import { StateVectorComponent } from "../../src";
@@ -6,7 +6,7 @@ import { STATE_VECTOR_EVENTS } from "../../src/state-vector-events";
 
 describe("StateVectorComponent", () => {
   let stateVector: StateVectorComponent;
-  const mockScrollRect = new PIXI.Rectangle(0, 0, 1000, 1000);
+  const mockScrollRect = new Rectangle(0, 0, 1000, 1000);
 
   beforeEach(() => {
     stateVector = new StateVectorComponent({
@@ -37,7 +37,7 @@ describe("StateVectorComponent", () => {
   });
 
   it("should adjust scroll correctly", () => {
-    const newScrollRect = new PIXI.Rectangle(500, 500, 1500, 1500);
+    const newScrollRect = new Rectangle(500, 500, 1500, 1500);
     const mockEmit = vi.spyOn(stateVector, "emit");
     stateVector.setViewport(newScrollRect);
     expect(mockEmit).toHaveBeenCalledWith(
@@ -54,7 +54,7 @@ describe("StateVectorComponent", () => {
 
   it("should update visible amplitudes when scrolling", () => {
     stateVector.qubitCount = 4; // 16個のQubitCircleを作成
-    const newScrollRect = new PIXI.Rectangle(100, 100, 100, 100);
+    const newScrollRect = new Rectangle(100, 100, 100, 100);
     stateVector.setViewport(newScrollRect);
     expect(stateVector.visibleQubitCircleIndices.length).toBeLessThan(16);
   });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,21 +2,21 @@ import { VitePWA } from "vite-plugin-pwa";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  build: {
-    rollupOptions: {
-      output: {
-        manualChunks(id) {
-          if (id.includes("node_modules")) {
-            return id
-              .toString()
-              .split("node_modules/")[1]
-              .split("/")[0]
-              .toString();
-          }
-        },
-      },
-    },
-  },
+  // build: {
+  //   rollupOptions: {
+  //     output: {
+  //       manualChunks(id) {
+  //         if (id.includes("node_modules")) {
+  //           return id
+  //             .toString()
+  //             .split("node_modules/")[1]
+  //             .split("/")[0]
+  //             .toString();
+  //         }
+  //       },
+  //     },
+  //   },
+  // },
   plugins: [
     VitePWA({
       srcDir: "src",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,21 +2,15 @@ import { VitePWA } from "vite-plugin-pwa";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  // build: {
-  //   rollupOptions: {
-  //     output: {
-  //       manualChunks(id) {
-  //         if (id.includes("node_modules")) {
-  //           return id
-  //             .toString()
-  //             .split("node_modules/")[1]
-  //             .split("/")[0]
-  //             .toString();
-  //         }
-  //       },
-  //     },
-  //   },
-  // },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          pixi: ["pixi.js"],
+        },
+      },
+    },
+  },
   plugins: [
     VitePWA({
       srcDir: "src",


### PR DESCRIPTION
@HidemotoNakada PIXI.js のロードエラーを修正しました。*.js のチャンク分割をカスタマイズしていたのですが、新しくなった PIXI.js ではうまく動作しなかったようです。ですのでチャンク分割を普通に戻しました。

```ts
export default defineConfig({
  build: {
    rollupOptions: {
      output: {
        manualChunks: {
          pixi: ["pixi.js"],
        },
      },
    },
  },
  // ...
```

この修正でうまく動作はしますが pixi のチャンクがやや大きくなってしまいます。これについては動的 import など別の方法で解決しようと思います。